### PR TITLE
feat(dojo): add git-filter-repo to Dockerfile for challenge support

### DIFF
--- a/challenge/Dockerfile_amd64
+++ b/challenge/Dockerfile_amd64
@@ -555,6 +555,7 @@ RUN xargs pip install --force-reinstall <<EOF
     r2pipe
     requests
     selenium
+    git-filter-repo
 EOF
 
 RUN ln -sf /usr/bin/ipython3 /usr/bin/ipython


### PR DESCRIPTION
Install git-filter-repo in the Dockerfile to enable its use in Git challenge levels, enhancing Git history manipulation capabilities for users.