### PR TITLE
feat(dojo): add git-filter-repo to Dockerfile_arm64 for challenge support

### DIFF
--- a/challenge/Dockerfile_arm64
+++ b/challenge/Dockerfile_arm64
@@ -487,6 +487,7 @@ RUN xargs pip install --force-reinstall <<EOF
     r2pipe
     requests
     selenium
+    git-filter-repo
 EOF
 
 RUN ln -sf /usr/bin/ipython3 /usr/bin/ipython


### PR DESCRIPTION
Install git-filter-repo in Dockerfile_arm64 to enable its use in Git challenge levels on arm64 architectures, ensuring consistent Git tooling across platforms.