### PR TITLE
fix: support openai API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo '{ "data-root": "/opt/pwn.college/data/docker" }' > /etc/docker/daemon.
 RUN docker buildx install
 RUN git clone --branch 3.6.0 https://github.com/CTFd/CTFd /opt/CTFd
 
-RUN git clone --branch dojo https://github.com/CeS-3/sensai.git /opt/sensai
+RUN git clone --branch dojo https://github.com/hust-open-atom-club/sensai.git /opt/sensai
 
 RUN wget -O /etc/docker/seccomp.json https://gitee.com/mirrors/moby/raw/master/profiles/seccomp/default.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN echo '{ "data-root": "/opt/pwn.college/data/docker" }' > /etc/docker/daemon.
 RUN docker buildx install
 RUN git clone --branch 3.6.0 https://github.com/CTFd/CTFd /opt/CTFd
 
+RUN git clone --branch dojo https://github.com/CeS-3/sensai.git /opt/sensai
+
 RUN wget -O /etc/docker/seccomp.json https://gitee.com/mirrors/moby/raw/master/profiles/seccomp/default.json
 
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.service /etc/systemd/system/pwn.college.service

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       - KOOK_CLIENT_SECRET=${KOOK_CLIENT_SECRET}
       - KOOK_APP_ID=${KOOK_APP_ID}
       - OLLAMA_BASE_URLS=${OLLAMA_BASE_URLS}
+      - OPENAI_API_BASE_URL=${OPENAI_API_BASE_URL}
     volumes:
       - ./data:/var/data
       - ./data/CTFd/logs:/var/log/CTFd
@@ -190,9 +191,11 @@ services:
 
   open-webui:
     container_name: open-webui
-    image: cees3/sensai:v2.37
+    build: /opt/sensai
     environment:
       - OLLAMA_BASE_URLS=${OLLAMA_BASE_URLS}
+      - OPENAI_API_BASE_URL=${OPENAI_API_BASE_URL}
+      - HF_ENDPOINT=https://hf-mirror.com
     volumes:
       - open-webui:/app/backend/data
     networks:

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -38,6 +38,7 @@ define KOOK_CLIENT_ID
 define KOOK_CLIENT_SECRET
 define KOOK_APP_ID
 define OLLAMA_BASE_URLS
+define OPENAI_API_BASE_URL
 
 mv $DOJO_DIR/data/.config.env $DOJO_DIR/data/config.env
 . $DOJO_DIR/data/config.env

--- a/dojo_plugin/pages/sensai.py
+++ b/dojo_plugin/pages/sensai.py
@@ -17,9 +17,11 @@ sensai = Blueprint("pwncollege_sensai", __name__)
 def view_sensai():
     import os
     ollama_base_urls = os.environ.get("OLLAMA_BASE_URLS", "")
+    openai_api_base_url = os.environ.get("OPENAI_API_BASE_URL", "")
     enable_ollama = ollama_base_urls and ollama_base_urls != '""' and ollama_base_urls != "''"
+    enable_openai = openai_api_base_url and openai_api_base_url != '""' and openai_api_base_url != "''"
     active = bool(get_current_dojo_challenge())
-    return render_template("iframe.html", iframe_name="sensai", iframe_src="/sensai/", active=active, enable_ollama=enable_ollama)
+    return render_template("iframe.html", iframe_name="sensai", iframe_src="/sensai/", active=active, enable_ollama=enable_ollama, enable_openai=enable_openai)
 
 
 @sensai.route("/sensai/", methods=["GET", "POST", "DELETE", "OPTIONS"])

--- a/dojo_theme/templates/iframe.html
+++ b/dojo_theme/templates/iframe.html
@@ -36,7 +36,7 @@
 {% endblock %}
 
 {% block content %}
-{% if iframe_name == "sensai" and not enable_ollama %}
+{% if iframe_name == "sensai" and not enable_ollama and not enable_openai %}
 <h1 class="inactive">本服务未启用<h1>
 {% elif active %}
   <iframe src="{{ iframe_src }}"></iframe>


### PR DESCRIPTION
**This commit adds support for OpenAI API integration in the SensAI service and updates the build process for the open-webui container.**

**Purpose:**  
This update is intended to enable OpenAI API functionality within the SensAI service by introducing a new environment variable for the API base URL, cloning the SensAI repository during the Docker build process, and switching the open-webui container from a pre-built image to a local build. Additionally, it configures a Hugging Face mirror for improved accessibility in restricted networks, ensuring seamless integration and model loading for AI-related features.

**Key Changes:**

- **Updated Dockerfile:**  
  - Added a new RUN command to clone the SensAI repository from GitHub (branch: dojo) into /opt/sensai, enabling local building of the SensAI components.

- **Updated docker-compose.yml:**  
  - Changed the open-webui service from using a pre-built image (cees3/sensai:v2.37) to building from /opt/sensai.  
  - Added environment variables for OPENAI_API_BASE_URL and HF_ENDPOINT (set to https://hf-mirror.com) to support OpenAI integration and Hugging Face mirroring.

- **Updated dojo/dojo-init script:**  
  - Added a new define for OPENAI_API_BASE_URL to ensure the variable is properly handled during initialization.

- **Updated dojo_plugin/pages/sensai.py:**  
  - Introduced handling for the OPENAI_API_BASE_URL environment variable and added logic to enable OpenAI features.  
  - Updated the render_template call to include an enable_openai flag for conditional rendering in the iframe.

- **Updated dojo_theme/templates/iframe.html:**  
  - Modified the conditional check to display a message only if neither OLLAMA nor OpenAI is enabled, improving user feedback for disabled services.