### PR TITLE
fix: harden SSO login, git private key handling, and challenge networking

### DIFF
--- a/challenge/Dockerfile_amd64
+++ b/challenge/Dockerfile_amd64
@@ -231,7 +231,10 @@ FROM builder-gdb-${INSTALL_GDB} AS builder-gdb
 FROM essentials AS builder-code-server
 
 RUN <<EOF
-    curl -fsSL https://gitee.com/mirrors/code-server/raw/main/install.sh | /bin/sh /dev/stdin
+    # Local customization (HUST): pin code-server to v4.103.2 (2025-08-25).
+    # Newer code-server versions moved @vscode/ripgrep/bin/rg (now bundled in the
+    # Copilot extension), which breaks the rg wrapper steps below.
+    curl -fsSL https://gitee.com/mirrors/code-server/raw/main/install.sh | VERSION=4.103.2 /bin/sh /dev/stdin
     mkdir -p /opt/code-server/extensions
     wget -O /tmp/ms-vscode-cpptools.vsix 'https://github.com/microsoft/vscode-cpptools/releases/download/v1.20.5/cpptools-linux.vsix'    
     code-server --extensions-dir=/opt/code-server/extensions \

--- a/dojo/dojo-init
+++ b/dojo/dojo-init
@@ -90,6 +90,7 @@ for host in $(cat $DOJO_DIR/user_firewall.allowed); do
     iptables -I DOCKER-USER -i user_network -d $(host $host | awk '{print $NF; exit}') -j ACCEPT
 done
 iptables -I DOCKER-USER -i user_network -s 10.114.0.0/24 -m conntrack --ctstate NEW -j ACCEPT
+iptables -I DOCKER-USER -i user_network -s 10.114.0.0/24 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables -I DOCKER-USER -i user_network -d 10.114.0.0/16 -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 
 iptables -I DOCKER-USER -i user_network -p tcp --dport 3000 -j ACCEPT

--- a/dojo_plugin/api/v1/sso_login.py
+++ b/dojo_plugin/api/v1/sso_login.py
@@ -18,7 +18,7 @@ class Settings:
         self.CAS_EXTRA_LOGIN_PARAMS = None
         self.CAS_IGNORE_REFERER = False
         self.CAS_LOGOUT_COMPLETELY = True
-        self.CAS_REDIRECT_URL = 'http://pwn.cse.hust.edu.cn/cas-login/'
+        self.CAS_REDIRECT_URL = 'https://pwn.cse.hust.edu.cn/cas-login/'
         self.CAS_RETRY_LOGIN = False
         self.CAS_VERSION = '2'
 
@@ -102,8 +102,10 @@ class CASBackend(object):
     def authenticate(self,ticket):
         service = settings.CAS_REDIRECT_URL
         username = _verify_cas2(ticket, service)
+        if username is None:
+            return None
         user = Users.query.filter_by(oauth_id=username[1:]).first()
-        
+
         if user :
             return user
         else:

--- a/dojo_plugin/utils/dojo.py
+++ b/dojo_plugin/utils/dojo.py
@@ -326,7 +326,7 @@ def dojo_clone(repository_type, repository, private_key):
     clone_dir = tempfile.TemporaryDirectory(dir=tmp_dojos_dir)  # TODO: ignore_cleanup_errors=True
 
     key_file = tempfile.NamedTemporaryFile("w")
-    key_file.write(private_key)
+    key_file.write(private_key.strip() + "\n")
     key_file.flush()
 
     if repository_type == "github":
@@ -351,7 +351,7 @@ def dojo_clone(repository_type, repository, private_key):
 
 def dojo_git_command(dojo, *args):
     key_file = tempfile.NamedTemporaryFile("w")
-    key_file.write(dojo.private_key)
+    key_file.write(dojo.private_key.strip() + "\n")
     key_file.flush()
 
     return subprocess.run(["git", "-C", str(dojo.path), *args],


### PR DESCRIPTION
- sso_login: use https CAS redirect URL; guard against None username from _verify_cas2
- dojo: strip whitespace and ensure trailing newline on SSH private keys
- dojo-init: allow ESTABLISHED,RELATED return traffic from user_network
- challenge: pin code-server to v4.103.2 (newer versions break the rg wrapper)