### PR TITLE
fix(sshd): exclude dockerd-injected vars from /etc/environment

### DIFF
--- a/sshd/start.sh
+++ b/sshd/start.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 # adamd: hack here so that the auth.py command can get the environment variables we set in the docker compose
-printenv | grep -v "no_proxy" >> /etc/environment
+# Only propagate variables set by the compose config: dockerd injects process-state vars (HOME/PWD/SHLVL/HOSTNAME)
+# into PID 1, and without filtering them pam_env applies HOME=/root to every SSH session, breaking tools that
+# resolve the user's real home (e.g. docker CLI reading ~/.docker/config.json → "permission denied").
+printenv | grep -v "no_proxy" | grep -vE "^(HOME|PWD|SHLVL|HOSTNAME)=" >> /etc/environment
 
 /usr/sbin/sshd.pam -D -e -f /opt/sshd/sshd_config


### PR DESCRIPTION
pam_env applied HOME=/root (injected by dockerd, not compose config) to every SSH session, breaking docker CLI config lookup in enter.py and causing 'WARNING: Error loading config file: ... permission denied' on login. Filter out process-state vars (HOME/PWD/SHLVL/HOSTNAME).