### PR TITLE
fix: update seccomp profile download URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN echo '{ "data-root": "/opt/pwn.college/data/docker" }' > /etc/docker/daemon.
 RUN docker buildx install
 RUN git clone --branch 3.6.0 https://github.com/CTFd/CTFd /opt/CTFd
 
-RUN wget -O /etc/docker/seccomp.json https://gitee.com/mirrors/moby/raw/master/profiles/seccomp/default.json
+RUN wget -O /etc/docker/seccomp.json https://raw.githubusercontent.com/moby/profiles/main/seccomp/default.json
 
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.service /etc/systemd/system/pwn.college.service
 RUN ln -s /opt/pwn.college/etc/systemd/system/pwn.college.backup.service /etc/systemd/system/pwn.college.backup.service


### PR DESCRIPTION
## Summary

- replace the Gitee Moby mirror URL that now returns HTTP 403
- download the default seccomp profile from the official `moby/profiles` repository

## Validation

- downloaded the new URL successfully and parsed it with `jq`
- confirmed the profile contains `defaultAction` and a syscall array
- confirmed the devcontainer image build passes the previously failing download step and exports the image
- `git diff --check`