### PR TITLE
fix(theme): use local discord logo as settings avatar

### DIFF
--- a/dojo_theme/templates/settings.html
+++ b/dojo_theme/templates/settings.html
@@ -134,7 +134,7 @@
         {% if discord_enabled %}
         <div class="tab-pane fade" id="discord" role="tabpanel">
           <div class="text-center">
-            <img src="{{ discord_avatar_asset(discord_member) }}" class="discord-avatar">
+            <img src="{{ url_for('views.themes', path='img/dojo/discord_logo.svg') }}" class="discord-avatar">
             {% if discord_user %}
               {% if discord_member %}
                 <h2>{{ discord_member["user"]["username"] }}</h2>


### PR DESCRIPTION
cdn.discordapp.com avatar URLs are unreachable from mainland China, so the Discord avatar <img> rendered broken on the settings page. Render the bundled discord_logo.svg instead (discord_avatar_asset kept for compatibility).