### PR TITLE
fix(plugin): add templates/scripts to DojoChallenge for admin panel

### DIFF
--- a/dojo_plugin/__init__.py
+++ b/dojo_plugin/__init__.py
@@ -43,6 +43,16 @@ from .api import api
 class DojoChallenge(BaseChallenge):
     id = "dojo"
     name = "dojo"
+    templates = {
+        "create": "/plugins/challenges/assets/create.html",
+        "update": "/plugins/challenges/assets/update.html",
+        "view": "/plugins/challenges/assets/view.html",
+    }
+    scripts = {
+        "create": "/plugins/challenges/assets/create.js",
+        "update": "/plugins/challenges/assets/update.js",
+        "view": "/plugins/challenges/assets/view.js",
+    }
     challenge_model = Challenges
 
     @classmethod


### PR DESCRIPTION
DojoChallenge inherits BaseChallenge.templates={} from CTFd, so opening /admin/challenges/<id> for any dojo-type challenge raised KeyError: 'update' in CTFd.admin.challenges_detail, returning 500. Provide the standard challenge create/update/view templates and scripts so the admin challenge detail page renders.