### PR TITLE
fix(plugin): allow viewing your own hidden hacker profile

### DIFF
--- a/dojo_plugin/pages/users.py
+++ b/dojo_plugin/pages/users.py
@@ -19,8 +19,8 @@ from ..utils.awards import get_belts, get_viewable_emojis
 users = Blueprint("pwncollege_users", __name__)
 
 
-def view_hacker(user):
-    if user.hidden:
+def view_hacker(user, bypass_hidden=False):
+    if user.hidden and not bypass_hidden:
         abort(404)
     dojos = Dojos.query.where(or_(and_(Dojos.official, Dojos.data["type"] != "course"), Dojos.data["type"] == "public")).all()
     # { dojo_id: { module_id: { challenge_id: completion_date } } }
@@ -62,7 +62,7 @@ def view_other_name(user_name):
 @users.route("/hacker/")
 @authed_only
 def view_self():
-    return view_hacker(get_current_user())
+    return view_hacker(get_current_user(), bypass_hidden=True)
 
 @users.route("/hacker/completion-report/")
 @authed_only


### PR DESCRIPTION
view_hacker unconditionally aborts with 404 when user.hidden is set, which also breaks view_self(): a hidden user (e.g. the admin account, hidden to stay off leaderboards) gets a 404 on their own /hacker/ page.

Port upstream's bypass_hidden flag (upstream commits 3b19de9a, dcb4ac5d) so the owner can view their own profile while other users' views of hidden profiles still 404.