### PR TITLE
feat(theme): add mevinagrise to ops team on homepage

### DIFF
--- a/dojo_theme/templates/index.html
+++ b/dojo_theme/templates/index.html
@@ -255,6 +255,7 @@
   <ul>
     <li><a href="https://github.com/mudongliang">慕冬亮</a> </li>
     <li><a href="https://github.com/wumingzhilian">丁鹏宇</a> </li>
+    <li><a href="https://github.com/mevinagrise">袁令羲</a> </li>
     <li><a href="https://github.com/huyinhao">胡崟昊</a> </li>
     <li><a href="https://github.com/CeS-3">黄宇浩</a> </li>
   </ul>


### PR DESCRIPTION
## 修改

在主页"运维团队"列表中，丁鹏宇与胡崟昊之间新增成员袁令羲（mevinagrise）。

Add 袁令羲 (mevinagrise) to the operations team list on the homepage, between 丁鹏宇 and 胡崟昊.

- 文件：`dojo_theme/templates/index.html`（+1 行）