### PR TITLE
fix: remove legacy desktop routes

### DIFF
--- a/dojo_plugin/pages/desktop.py
+++ b/dojo_plugin/pages/desktop.py
@@ -1,98 +1,11 @@
-import os
+from flask import Blueprint, render_template
+from CTFd.utils.decorators import admins_only
 
-from flask import request, Blueprint, render_template, abort
-from CTFd.utils.user import get_current_user, is_admin
-from CTFd.utils.decorators import authed_only, admins_only
-from CTFd.models import Users
-
-from ..utils import random_home_path, get_active_users, redirect_user_socket
-from ..utils.dojo import dojo_route, get_current_dojo_challenge
+from ..utils import get_active_users
 
 
 desktop = Blueprint("pwncollege_desktop", __name__)
 
-
-def can_connect_to(desktop_user):
-    return any((
-        is_admin(),
-        desktop_user.id == get_current_user().id,
-        os.path.exists(f"/var/homes/nosuid/{random_home_path(desktop_user)}/LIVE")
-    ))
-
-
-def can_control(desktop_user):
-    return any((
-        is_admin(),
-        desktop_user.id == get_current_user().id
-    ))
-
-
-def view_desktop_res(route, user_id=None, password=None):
-    current_user = get_current_user()
-    if user_id is None:
-        user_id = current_user.id
-
-    user = Users.query.filter_by(id=user_id).first()
-    if not can_connect_to(user):
-        abort(403)
-
-    if password is None:
-        try:
-            password_type = "interact" if can_control(user) else "view"
-            password_path = f"/var/homes/nosuid/{random_home_path(user)}/.vnc/pass-{password_type}"
-            password = open(password_path).read()
-        except FileNotFoundError:
-            password = None
-
-    active = bool(password) if get_current_dojo_challenge(user) is not None else None
-    view_only = int(user_id != current_user.id)
-
-    iframe_src = f"/{route}/{user_id}/vnc.html?autoconnect=1&reconnect=1&path={route}/{user_id}/websockify&resize=remote&reconnect_delay=10&view_only={view_only}&password={password}"
-    return render_template("iframe.html", iframe_src=iframe_src, active=active)
-
-
-@desktop.route("/desktop")
-@desktop.route("/desktop/<int:user_id>")
-@authed_only
-def view_desktop(user_id=None):
-    return view_desktop_res("desktop", user_id)
-
-
-@desktop.route("/desktop-win")
-@desktop.route("/desktop-win/<int:user_id>")
-@authed_only
-def view_desktop_win(user_id=None):
-    return view_desktop_res("desktop-win", user_id, "abcd")
-
-
-def forward_desktop_res(route, socket_path, user_id, path=""):
-    prefix = f"/{route}/{user_id}/"
-    assert request.full_path.startswith(prefix)
-    path = request.full_path[len(prefix):]
-
-    user = Users.query.filter_by(id=user_id).first()
-    if not can_connect_to(user):
-        abort(403)
-
-    return redirect_user_socket(user, socket_path, path)
-
-
-@desktop.route("/desktop/<int:user_id>/")
-@desktop.route("/desktop/<int:user_id>/<path:path>")
-@desktop.route("/desktop/<int:user_id>/", websocket=True)
-@desktop.route("/desktop/<int:user_id>/<path:path>", websocket=True)
-@authed_only
-def forward_desktop(user_id, path=""):
-    return forward_desktop_res("desktop", 6081, user_id, path)
-
-
-@desktop.route("/desktop-win/<int:user_id>/")
-@desktop.route("/desktop-win/<int:user_id>/<path:path>")
-@desktop.route("/desktop-win/<int:user_id>/", websocket=True)
-@desktop.route("/desktop-win/<int:user_id>/<path:path>", websocket=True)
-@authed_only
-def forward_desktop_win(user_id, path=""):
-    return forward_desktop_res("desktop-win", 6082, user_id, path)
 
 @desktop.route("/admin/desktops", methods=["GET"])
 @admins_only

--- a/dojo_theme/templates/admin_desktops.html
+++ b/dojo_theme/templates/admin_desktops.html
@@ -18,7 +18,7 @@
         <tbody>
           {% for user in users %}
           <tr>
-            <td><a href="/desktop/{{ user.id }}">{{ user.name }}</a></td>
+            <td><a href="{{ url_for('pwncollege_workspace.view_desktop', user=user.id) }}">{{ user.name }}</a></td>
           </tr>
           {% endfor %}
         </tbody>


### PR DESCRIPTION
## Summary

- remove the legacy `/desktop` and `/desktop-win` page and proxy routes
- remove the fixed `desktop-win` VNC password path
- migrate the admin desktop list to the current `/workspace/desktop` endpoint

## Validation

- `git diff --check`
- `python3 -m compileall -q dojo_plugin/pages/desktop.py dojo_plugin/pages/workspace.py`
- verified no `desktop-win`, fixed-password, or legacy desktop route references remain
- verified the navbar, challenge-start message, share URLs, and admin desktop list use the current workspace routes

## Testing

Full container integration tests were not run because they require a running dojo deployment.
