### PR TITLE
fix(sshd): skip SSL for internal ssh_keys query

### DIFF
--- a/sshd/auth.py
+++ b/sshd/auth.py
@@ -32,7 +32,10 @@ def main():
     enter_path = pathlib.Path(__file__).parent.resolve() / "enter.py"
 
     connect_arg = f"-h{DB_HOST}" if DB_HOST else ""
-    result = subprocess.run(["mysql", connect_arg, f"-p{DB_PASS}", f"-u{DB_USER}", f"-D{DB_NAME}", "-sNe", 'select value, user_id from ssh_keys;'], stdout=subprocess.PIPE)
+    # --skip-ssl: this query runs over the internal compose network; disable SSL
+    # to avoid failure when the MariaDB client requires SSL but the server does
+    # not support it (which would break SSH public key authentication).
+    result = subprocess.run(["mysql", connect_arg, f"-p{DB_PASS}", f"-u{DB_USER}", f"-D{DB_NAME}", "--skip-ssl", "-sNe", 'select value, user_id from ssh_keys;'], stdout=subprocess.PIPE)
     if result.returncode != 0:
         error(f"Error: db query exited with code '{result.returncode}'")
 


### PR DESCRIPTION
## Summary

Fixes #159. `sshd/auth.py` queries the `ssh_keys` table via the mysql CLI. The client installed from `alpine:latest` (MariaDB client 11.x, Connector/C >= 3.3) requires SSL by default, but the `db` service runs `mariadb:10.4.12` with SSL disabled (`have_ssl=DISABLED`). The query fails with:

```
ERROR 2026 (HY000): TLS/SSL error: SSL is required, but the server does not support it
```

`auth.py` then exits with code 1, `AuthorizedKeysCommand` outputs nothing, and SSH public key authentication fails (`Permission denied (publickey)`) even though the user configured a key.

Add `--skip-ssl` with an explanatory comment: this query runs over the trusted internal compose network (sshd and db on the same Docker network, db not exposed to the public network). If the database is later migrated to an untrusted network, TLS should be configured on the server instead.

## Validation

- Reproduced in production: without `--skip-ssl`, the query exits with code 1 and the `ERROR 2026` message above.
- With `--skip-ssl`, the query succeeds and returns key/user_id rows.

## Testing

- With `--skip-ssl` applied on the production sshd container, users can SSH into their challenge containers using configured public keys.
- Query result format is unchanged (single `select value, user_id from ssh_keys;`).