### PR TITLE
feat(compose): gate monitoring stack behind compose profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -223,6 +223,7 @@ services:
   # Prometheus 监控服务
   prometheus:
     container_name: prometheus
+    profiles: ["monitoring"]
     image: prom/prometheus:latest
     restart: always
     ports:
@@ -249,6 +250,7 @@ services:
   # Grafana 可视化服务
   grafana:
     container_name: grafana
+    profiles: ["monitoring"]
     image: grafana/grafana:latest
     restart: always
     environment:
@@ -272,6 +274,7 @@ services:
   # Node Exporter - 系统监控
   node-exporter:
     container_name: node-exporter
+    profiles: ["monitoring"]
     image: prom/node-exporter:latest
     restart: always
     ports:
@@ -295,6 +298,7 @@ services:
   # MySQL Exporter - 数据库监控
   mysql-exporter:
     container_name: mysql-exporter
+    profiles: ["monitoring"]
     image: prom/mysqld-exporter:latest
     restart: always
     ports:
@@ -313,6 +317,7 @@ services:
   # Redis Exporter - 缓存监控
   redis-exporter:
     container_name: redis-exporter
+    profiles: ["monitoring"]
     image: oliver006/redis_exporter:latest
     restart: always
     ports:
@@ -331,6 +336,7 @@ services:
   # Nginx Exporter - Web服务器监控
   nginx-exporter:
     container_name: nginx-exporter
+    profiles: ["monitoring"]
     image: nginx/nginx-prometheus-exporter:latest
     restart: always
     ports:


### PR DESCRIPTION
## Summary

Move the monitoring stack (prometheus, grafana, node/mysql/redis/nginx exporters) behind the `monitoring` compose profile, making it opt-in instead of starting unconditionally on every deployment:

```
dojo compose --profile monitoring up -d
```

Default deployments no longer pull the 6 monitoring images or bind ports 9090/9100/9104/9113/9121. The nginx `/monitoring` reverse proxy and the named volumes (`prometheus_data`, `grafana_data`) are left untouched: volumes are only created when a service references them, and when the profile is disabled the `/monitoring` route returns 502.

## Validation

- `docker compose config -q` passes.
- `docker compose config --services` lists 0 monitoring services by default; with `--profile monitoring` all 6 appear.

## Testing

- Verified service gating with `docker compose config --services` / `--profile monitoring config --services`.
- Existing non-monitoring services are unchanged (no other diff in this file).