### PR TITLE
build: upgrade CTFd runtime to Python 3.13

### DIFF
--- a/ctfd/Dockerfile
+++ b/ctfd/Dockerfile
@@ -1,11 +1,6 @@
-FROM python:3.9-slim-buster AS build
+FROM python:3.13.4-slim AS build
 WORKDIR /opt/CTFd
 
-RUN sed -i \
-        -e 's|deb.debian.org/debian-security|archive.debian.org/debian-security|g' \
-        -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
-        /etc/apt/sources.list \
-    && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -22,24 +17,21 @@ COPY requirements.txt /opt/CTFd/
 RUN pip install --no-cache-dir -r requirements.txt
 
 # TODO: Remove this when CTFd depends on Flask >= 2.1.0: "safe_join is removed, use werkzeug.utils.safe_join instead"
-RUN echo 'from werkzeug.utils import safe_join' >> /opt/venv/lib/python3.9/site-packages/flask/helpers.py
+RUN python -c 'import flask.helpers; print(flask.helpers.__file__)' \
+    | xargs -I {} sh -c "echo 'from werkzeug.utils import safe_join' >> '{}'"
 
 COPY . /opt/CTFd
 
-FROM python:3.9-slim-buster AS release
+FROM python:3.13.4-slim AS release
 WORKDIR /opt/CTFd
 
-RUN sed -i \
-        -e 's|deb.debian.org/debian-security|archive.debian.org/debian-security|g' \
-        -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
-        /etc/apt/sources.list \
-    && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        libffi6 \
-        libssl1.1 \
+        libffi8 \
+        libssl3 \
         git \
         openssh-client \
+        patch \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/ctfd/Dockerfile
+++ b/ctfd/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.9-slim-buster AS build
 WORKDIR /opt/CTFd
 
-RUN sed -i.bak 's|https\?://archive.ubuntu.com|http://mirrors.hust.edu.cn|g' /etc/apt/sources.list
+RUN sed -i \
+        -e 's|deb.debian.org/debian-security|archive.debian.org/debian-security|g' \
+        -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+        /etc/apt/sources.list \
+    && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential \
@@ -25,7 +29,11 @@ COPY . /opt/CTFd
 FROM python:3.9-slim-buster AS release
 WORKDIR /opt/CTFd
 
-RUN sed -i.bak 's|https\?://archive.ubuntu.com|http://mirrors.hust.edu.cn|g' /etc/apt/sources.list
+RUN sed -i \
+        -e 's|deb.debian.org/debian-security|archive.debian.org/debian-security|g' \
+        -e 's|deb.debian.org/debian|archive.debian.org/debian|g' \
+        /etc/apt/sources.list \
+    && printf 'Acquire::Check-Valid-Until "false";\n' > /etc/apt/apt.conf.d/99archive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         libffi6 \

--- a/ctfd/requirements.txt
+++ b/ctfd/requirements.txt
@@ -1,6 +1,6 @@
 # DOJO
 docker==6.1.2
-pyyaml==5.4.1
+pyyaml==6.0.2
 schema==0.7.5
 bleach==6.1.0
 ipython==8.16.1
@@ -26,7 +26,7 @@ gunicorn==22.0.0
 dataset==1.5.2
 cmarkgfm==2022.10.27
 redis==4.5.5
-gevent==23.9.1
+gevent==25.5.1
 python-dotenv==0.13.0
 flask-restx==1.1.0
 flask-marshmallow==0.10.1
@@ -38,6 +38,8 @@ WTForms==2.3.1
 python-geoacumen-city==2023.4.15
 maxminddb==1.5.4
 tenacity==6.2.0
-pybluemonday==0.0.12
-freezegun==1.2.2
+pybluemonday==0.0.14
+freezegun==1.5.3
 Flask-Babel==2.0.0
+legacy-cgi==2.6.3
+setuptools==80.9.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - /bin/sh
       - -c
       - |
-        patch  -i /opt/pwn.college/ctfd/0001-use-pycountry-to-replace-self-generated-country-list.patch /opt/CTFd/CTFd/utils/countries/__init__.py
+        patch -i /opt/CTFd/0001-use-pycountry-to-replace-self-generated-country-list.patch /opt/CTFd/CTFd/utils/countries/__init__.py
         if [ "$DOJO_ENV" != "development" ]; then
           ./docker-entrypoint.sh;
         else


### PR DESCRIPTION
## Summary

- upgrade the CTFd build and release images from Python 3.9 on Debian Buster to `python:3.13.4-slim`
- replace obsolete runtime libraries with `libffi8` and `libssl3`, and install `patch` in the release image
- update PyYAML, gevent, pybluemonday, and freezegun for Python 3.13 compatibility
- add `legacy-cgi` and pin setuptools for dependencies that still rely on removed or legacy Python interfaces
- locate `flask/helpers.py` dynamically instead of hard-coding the Python 3.9 site-packages path
- apply the bundled country-list patch from the path copied into the CTFd image

## Validation

- the source patch was tested on the SSH 506 Docker environment
- `git diff --check`
- verified the final PR changes only `ctfd/Dockerfile`, `ctfd/requirements.txt`, and `docker-compose.yml`

This supersedes the earlier Debian Buster archive approach in this PR. The final net change upgrades the CTFd runtime instead of retaining Buster.