### PR TITLE
feat(theme): add QQ course group link

### DIFF
--- a/dojo_theme/templates/index.html
+++ b/dojo_theme/templates/index.html
@@ -276,6 +276,14 @@
       </div>
       <div class="col-lg-auto m-3">
         <figure>
+          <a class="text-decoration-none" href="https://qm.qq.com/q/GEdZXtTYw" aria-label="加入 pwn.hust.college 教育平台课程群">
+            <i class="fab fa-qq fa-5x"></i>
+            <figcaption>QQ 课程群</figcaption>
+          </a>
+        </figure>
+      </div>
+      <div class="col-lg-auto m-3">
+        <figure>
           <a class="text-decoration-none" href="https://kook.top/soUkFL">
             <img src="https://hust.openatom.club/assets/images/kook.png" style="height: 5em; width: 5em;">
             <figcaption>KOOK 社区服务器</figcaption>
@@ -302,4 +310,3 @@
   </div>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
## Summary

- add a QQ brand icon to the landing page resource section
- place the QQ course group entry immediately before the existing KOOK entry
- link to the `pwn.hust.college 教育平台课程群` invitation and provide an accessible label

## Validation

- `git diff --check`
- verified the PR changes only `dojo_theme/templates/index.html`
- verified the QQ entry precedes KOOK and uses `https://qm.qq.com/q/GEdZXtTYw`