### PR TITLE
fix(nginx): resolve grafana at request time to fix reload failure

### DIFF
--- a/nginx-proxy/etc/nginx/vhost.d/default_location
+++ b/nginx-proxy/etc/nginx/vhost.d/default_location
@@ -33,8 +33,14 @@ location /monitoring/ {
     proxy_buffering off;
     proxy_http_version 1.1;
 
-    # 代理并移除前缀
-    proxy_pass http://grafana:3000/monitoring/;
+    # Resolve "grafana" at request time (via a variable) instead of at reload:
+    # grafana runs behind the 'monitoring' compose profile, and a static
+    # proxy_pass makes nginx resolve the hostname on every reload, which fails
+    # with 'host not found in upstream "grafana"' when the profile is disabled.
+    # With a variable, reload always succeeds; this path returns 502 while
+    # grafana is not running and works normally once the profile is enabled.
+    set $grafana_upstream grafana;
+    proxy_pass http://$grafana_upstream:3000/monitoring/;
 }
 
 location /nginx_status {


### PR DESCRIPTION
## Problem

After #161 moved the monitoring stack behind the `monitoring` compose profile, nginx reload fails whenever grafana is not running:

```
nginx: [emerg] host not found in upstream "grafana" in /etc/nginx/vhost.d/default_location:41
```

The `/monitoring/` location uses a static `proxy_pass http://grafana:3000`, which nginx resolves at reload time. With grafana behind a disabled profile, any reload (e.g. by nginx-proxy itself when containers start/stop) kills the whole nginx process — taking down the platform, not just the monitoring panel.

## Fix

Resolve `grafana` at request time instead, using an nginx variable:

```nginx
set $grafana_upstream grafana;
proxy_pass http://$grafana_upstream:3000/monitoring/;
```

- `nginx -t` and reload always succeed, regardless of whether grafana is running
- `/monitoring/` returns 502 while the profile is disabled (expected)
- Proxying works normally once the profile is enabled (verified end-to-end)

## Validation (production-like)

| Scenario | Result |
|---|---|
| reload with grafana stopped | OK, no emerg |
| `/monitoring/` with grafana stopped | 502 |
| `/monitoring/` with grafana running | 200, content served |
| platform root with grafana stopped | 200 |

Validated on the production server with a temporary grafana-like container on `user_network`, then reverted.