### PR TITLE
feat(theme): add Discord community server link

### DIFF
--- a/dojo_theme/templates/index.html
+++ b/dojo_theme/templates/index.html
@@ -292,6 +292,14 @@
       </div>
       <div class="col-lg-auto m-3">
         <figure>
+          <a class="text-decoration-none" href="https://discord.gg/34UKQhfSG" aria-label="加入 pwn.hust.college Discord 社区服务器">
+            <i class="fab fa-discord fa-5x"></i>
+            <figcaption>Discord 社区服务器</figcaption>
+          </a>
+        </figure>
+      </div>
+      <div class="col-lg-auto m-3">
+        <figure>
           <a class="text-decoration-none" href="https://github.com/hust-open-atom-club/pwn.hust.college">
             <i class="fab fa-github fa-5x"></i>
             <figcaption>平台代码仓库</figcaption>


### PR DESCRIPTION
## Summary

- add a Discord community server entry to the landing page resource section, immediately after the KOOK entry
- use the FontAwesome `fab fa-discord fa-5x` icon, consistent with the existing GitHub/mail entries
- link to `https://discord.gg/34UKQhfSG` with an accessible Chinese aria-label

## Validation

- `git diff --check` clean
- verified in production (pwn.cse.hust.edu.cn): template renders instantly, entry appears right after KOOK in the row
- Discord invite link verified reachable (200, redirects to discord.com/invite/34UKQhfSG)
- `fa-discord` glyph confirmed present in the theme's Font Awesome Free 5.14.0 brand font

## Testing

- applied and tested on the production landing page; diff against backup contains only the 8 added lines