### PR TITLE
feat(theme): add Discord community link

### DIFF
--- a/dojo_theme/templates/index.html
+++ b/dojo_theme/templates/index.html
@@ -284,6 +284,14 @@
       </div>
       <div class="col-lg-auto m-3">
         <figure>
+          <a class="text-decoration-none" href="https://discord.gg/z5Z4tEXK3x" aria-label="加入 pwn.hust.college Discord 社区服务器">
+            <i class="fab fa-discord fa-5x"></i>
+            <figcaption>Discord 社区服务器</figcaption>
+          </a>
+        </figure>
+      </div>
+      <div class="col-lg-auto m-3">
+        <figure>
           <a class="text-decoration-none" href="https://kook.top/soUkFL">
             <img src="https://hust.openatom.club/assets/images/kook.png" style="height: 5em; width: 5em;">
             <figcaption>KOOK 社区服务器</figcaption>


### PR DESCRIPTION
## Summary

- add a Discord brand icon to the landing page resource section
- place the Discord entry after the QQ course group and before KOOK
- link to `https://discord.gg/z5Z4tEXK3x` and provide an accessible label

## Validation

- `git diff --check`
- verified the PR changes only `dojo_theme/templates/index.html`
- verified the final order is QQ, Discord, then KOOK