### PR TITLE
ci: remove Docker Hub upload job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,24 +195,3 @@ jobs:
           echo "::group::Filesystem"
           df -h
           echo "::endgroup::"
-
-  upload:
-    name: Upload Artifacts
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.ref == 'refs/heads/master'
-    steps:
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          push: true
-          tags: pwncollege/dojo:latest


### PR DESCRIPTION
The dojo image is built and served from this repo's own CI/storage, not Docker Hub, so the Upload Artifacts job only ever failed (no DOCKERHUB_USERNAME/DOCKERHUB_TOKEN secrets on this fork) and turned every green master run red.

Remove the job entirely — tests are the only thing this CI needs to run.