### PR TITLE
ci: test singlenode only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        mode: [singlenode, multinode]
+        # pwn.hust.college is deployed as a single node; multinode
+        # coverage is only meaningful for the upstream project.
+        mode: [singlenode]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
pwn.hust.college is deployed as a single node, so the multinode matrix leg only duplicates CI time without testing anything that runs in production.

Restrict the matrix to `singlenode`; the upstream project still covers multinode in its own CI.